### PR TITLE
Upgrade to Python 3.8

### DIFF
--- a/README.md
+++ b/README.md
@@ -239,9 +239,9 @@ support old operating systems then choose the v31 release.
 
 OS | Py2 | Py3 | 32bit | 64bit | Requirements
 --- | --- | --- | --- | --- | ---
-Windows | 2.7 | 3.4 / 3.5 / 3.6 / 3.7 | Yes | Yes | Windows 7+
-Linux | 2.7 | 3.4 / 3.5 / 3.6 / 3.7 | Yes | Yes | Debian 8+, Ubuntu 14.04+, Fedora 24+, openSUSE 13.3+
-Mac | 2.7 | 3.4 / 3.5 / 3.6 / 3.7 | No | Yes | MacOS 10.9+
+Windows | 2.7 | 3.4 / 3.5 / 3.6 / 3.7 / 3.8 | Yes | Yes | Windows 7+
+Linux | 2.7 | 3.4 / 3.5 / 3.6 / 3.7 / 3.8 | Yes | Yes | Debian 8+, Ubuntu 14.04+, Fedora 24+, openSUSE 13.3+
+Mac | 2.7 | 3.4 / 3.5 / 3.6 / 3.7 / 3.8 | No | Yes | MacOS 10.9+
 
 These platforms are not supported yet:
 - ARM - see [Issue #267](../../issues/267)

--- a/src/common/cefpython_public_api.h
+++ b/src/common/cefpython_public_api.h
@@ -46,6 +46,8 @@
 #include "../../build/build_cefpython/cefpython_py36_fixed.h"
 #elif PY_MINOR_VERSION == 7
 #include "../../build/build_cefpython/cefpython_py37_fixed.h"
+#elif PY_MINOR_VERSION == 8
+#include "../../build/build_cefpython/cefpython_py38_fixed.h"
 #endif // PY_MINOR_VERSION
 #endif // PY_MAJOR_VERSION
 

--- a/tools/automate.py
+++ b/tools/automate.py
@@ -171,7 +171,7 @@ def setup_options(docopt_args):
         if hasattr(Options, key2) and value is not None:
             setattr(Options, key2, value)
 
-    Options.tools_dir = os.path.dirname(os.path.realpath(__file__))
+    Options.tools_dir = os.path.dirname(os.path.abspath(__file__))
     Options.cefpython_dir = os.path.dirname(Options.tools_dir)
 
     if not Options.cef_git_url:
@@ -199,7 +199,7 @@ def setup_options(docopt_args):
 
     # --build-dir
     if Options.build_dir:
-        Options.build_dir = os.path.realpath(Options.build_dir)
+        Options.build_dir = os.path.abspath(Options.build_dir)
     else:
         Options.build_dir = os.path.join(Options.cefpython_dir, "build")
     if " " in Options.build_dir:
@@ -211,7 +211,7 @@ def setup_options(docopt_args):
 
     # --cef-build-dir
     if Options.cef_build_dir:
-        Options.cef_build_dir = os.path.realpath(Options.cef_build_dir)
+        Options.cef_build_dir = os.path.abspath(Options.cef_build_dir)
     else:
         Options.cef_build_dir = Options.build_dir
     if " " in Options.cef_build_dir:
@@ -714,7 +714,7 @@ def prepare_build_command(build_lib=False, vcvars=None):
             command.append(VS_PLATFORM_ARG)
         else:
             if int(Options.cef_branch) >= 2704:
-                command.append(VS2015_VCVARS)
+                command.append(VS2019_VCVARS)
             else:
                 command.append(VS2013_VCVARS)
             command.append(VS_PLATFORM_ARG)
@@ -893,7 +893,7 @@ def create_prebuilt_binaries():
 
 def get_available_python_compilers():
     all_python_compilers = OrderedDict([
-        ("2015", VS2015_VCVARS),
+        ("2019", VS2019_VCVARS),
     ])
     ret_compilers = OrderedDict()
     for msvs in all_python_compilers:

--- a/tools/build_distrib.py
+++ b/tools/build_distrib.py
@@ -79,7 +79,7 @@ NO_AUTOMATE = False
 ALLOW_PARTIAL = False
 
 # Python versions
-SUPPORTED_PYTHON_VERSIONS = [(2, 7), (3, 4), (3, 5), (3, 6), (3, 7)]
+SUPPORTED_PYTHON_VERSIONS = [(2, 7), (3, 4), (3, 5), (3, 6), (3, 7), (3, 8)]
 
 # Python search paths. It will use first Python found for specific version.
 # Supports replacement of one environment variable in path eg.: %ENV_KEY%.
@@ -613,7 +613,7 @@ def check_cpp_extension_dependencies_issue359(setup_dir, all_pythons):
         return
     checked_any = False
     for python in all_pythons:
-        if python["version2"] in ((3, 5), (3, 6), (3, 7)):
+        if python["version2"] in ((3, 5), (3, 6), (3, 7), (3, 8)):
             checked_any = True
             if not os.path.exists(os.path.join(setup_dir, "cefpython3",
                                                "msvcp140.dll")):

--- a/tools/common.py
+++ b/tools/common.py
@@ -477,6 +477,8 @@ def get_msvs_for_python(vs_prefix=False):
         return "VS2015" if vs_prefix else "2015"
     elif sys.version_info[:2] == (3, 7):
         return "VS2015" if vs_prefix else "2015"
+    elif sys.version_info[:2] == (3, 8):
+        return "VS2019" if vs_prefix else "2019"
     else:
         print("ERROR: This version of Python is not supported")
         sys.exit(1)

--- a/tools/common.py
+++ b/tools/common.py
@@ -219,6 +219,9 @@ SUBPROCESS_EXE = os.path.join(BUILD_SUBPROCESS,
 
 VS_PLATFORM_ARG = "x86" if ARCH32 else "amd64"
 
+VS2019_VCVARS = ("C:\\Program Files (x86)\\Microsoft Visual Studio\\2019"
+                 "\\Professional\\VC\\Auxiliary\\Build\\vcvarsall.bat")
+
 VS2015_VCVARS = ("C:\\Program Files (x86)\\Microsoft Visual Studio 14.0"
                  "\\VC\\vcvarsall.bat")
 

--- a/tools/installer/cefpython3.__init__.py
+++ b/tools/installer/cefpython3.__init__.py
@@ -60,5 +60,8 @@ elif sys.version_info[:2] == (3, 6):
 elif sys.version_info[:2] == (3, 7):
     # noinspection PyUnresolvedReferences
     from . import cefpython_py37 as cefpython
+elif sys.version_info[:2] == (3, 8):
+    # noinspection PyUnresolvedReferences
+    from . import cefpython_py38 as cefpython
 else:
     raise Exception("Python version not supported: " + sys.version)

--- a/tools/installer/cefpython3.setup.py
+++ b/tools/installer/cefpython3.setup.py
@@ -148,6 +148,7 @@ def main():
             "Programming Language :: Python :: 3.5",
             "Programming Language :: Python :: 3.6",
             "Programming Language :: Python :: 3.7",
+            "Programming Language :: Python :: 3.8",
             "Topic :: Desktop Environment",
             "Topic :: Internet",
             "Topic :: Internet :: WWW/HTTP",

--- a/tools/make_installer.py
+++ b/tools/make_installer.py
@@ -368,7 +368,8 @@ def copy_cpp_extension_dependencies_issue359(pkg_dir):
     # Python 3.5 / 3.6 / 3.7
     if os.path.exists(os.path.join(pkg_dir, "cefpython_py35.pyd")) \
             or os.path.exists(os.path.join(pkg_dir, "cefpython_py36.pyd")) \
-            or os.path.exists(os.path.join(pkg_dir, "cefpython_py37.pyd")):
+            or os.path.exists(os.path.join(pkg_dir, "cefpython_py37.pyd")) \
+            or os.path.exists(os.path.join(pkg_dir, "cefpython_py38.pyd")):
         search_paths = [
             # This is where Microsoft Visual C++ 2015 Update 3 installs
             # (14.00.24212).


### PR DESCRIPTION
Upstream cefpython still doesn't support Python 3.8. However there is an open PR for it: https://github.com/cztomczak/cefpython/issues/546. I've incorporated bits of that here, plus a few more additions.
